### PR TITLE
Add waiter bot structure and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ python manage.py load_initial_data path/to/data.json
 
 - Browse APIs at `/swagger/` or `/redoc/`.
 - CRUD endpoints are available under `/api/`.
+
+## Waiter bot
+
+This repository also ships with a small Telegram bot that helps waiters send
+orders to the kitchen. It relies on the same Django backend for menu data.
+See [waiter_bot/README.md](waiter_bot/README.md) for installation and usage
+instructions. The bot asks for a table number and then walks the waiter through
+choosing categories and dishes.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ django-cors-headers==4.7.0
 djangorestframework==3.16.0
 drf-yasg==1.21.10
 psycopg2-binary==2.9.10
+aiogram==3.6.0
+aiohttp==3.9.5
+aiosqlite==0.19.0

--- a/waiter_bot/README.md
+++ b/waiter_bot/README.md
@@ -1,0 +1,33 @@
+## Waiter Telegram Bot
+
+A simple Telegram bot helps waiters take orders by fetching menu data from the
+local Django API. Categories and dishes are retrieved using `aiohttp` and the
+completed order is stored in SQLite.
+
+### Running the bot
+
+1. Install dependencies (from the repository root):
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Set environment variables:
+
+```bash
+export BOT_TOKEN=<telegram bot token>
+# Optional chat id where orders are sent
+export BAR_CHAT_ID=<chat id>
+# Optional base URL of the Django API
+export API_BASE_URL=http://localhost:8000/api
+```
+
+3. Start the bot:
+
+```bash
+python -m waiter_bot.bot
+```
+
+The bot displays menu categories from the API, lets the waiter pick dishes,
+saves the order to SQLite and optionally forwards it to the configured bar chat.
+On `/start` the bot first asks for a table number before showing menu categories.

--- a/waiter_bot/__init__.py
+++ b/waiter_bot/__init__.py
@@ -1,0 +1,3 @@
+"""Telegram waiter bot package."""
+
+__all__ = ["bot", "handlers", "db", "menu"]

--- a/waiter_bot/bot.py
+++ b/waiter_bot/bot.py
@@ -1,0 +1,29 @@
+import asyncio
+import os
+
+from aiogram import Bot, Dispatcher
+from aiogram.fsm.storage.memory import MemoryStorage
+
+from .handlers import register_handlers
+
+
+def main() -> None:
+    token = os.getenv("BOT_TOKEN")
+    if not token:
+        print("BOT_TOKEN environment variable is required")
+        return
+
+    bot = Bot(token)
+    dp = Dispatcher(storage=MemoryStorage())
+    register_handlers(dp)
+
+    asyncio.run(_run(bot, dp))
+
+
+async def _run(bot: Bot, dp: Dispatcher) -> None:
+    await bot.delete_webhook(drop_pending_updates=True)
+    await dp.start_polling(bot)
+
+
+if __name__ == "__main__":
+    main()

--- a/waiter_bot/db.py
+++ b/waiter_bot/db.py
@@ -1,0 +1,29 @@
+import json
+import os
+import aiosqlite
+
+DB_PATH = os.path.join(os.path.dirname(__file__), "orders.db")
+
+CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS orders (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    waiter_name TEXT,
+    table_number INTEGER,
+    items TEXT NOT NULL
+)
+"""
+
+async def init_db():
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(CREATE_TABLE_SQL)
+        await db.commit()
+
+async def save_order(items: list, waiter_name: str | None = None, table_number: int | None = None) -> None:
+    await init_db()
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "INSERT INTO orders (waiter_name, table_number, items) VALUES (?, ?, ?)",
+            (waiter_name, table_number, json.dumps(items)),
+        )
+        await db.commit()

--- a/waiter_bot/handlers.py
+++ b/waiter_bot/handlers.py
@@ -1,0 +1,104 @@
+import os
+from typing import Any, Dict, List
+
+from aiogram import Bot, Dispatcher, types
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+from .db import save_order
+from .menu import get_categories, get_dishes
+
+
+class OrderStates(StatesGroup):
+    choosing_table = State()
+    choosing_category = State()
+    choosing_dish = State()
+
+
+def categories_keyboard(categories: List[Dict[str, Any]]) -> InlineKeyboardMarkup:
+    buttons = [
+        [InlineKeyboardButton(text=c["name"], callback_data=f"cat:{c['id']}")]
+        for c in categories
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=buttons)
+
+
+def table_keyboard() -> InlineKeyboardMarkup:
+    buttons = [
+        [InlineKeyboardButton(text=str(i), callback_data=f"table:{i}")]
+        for i in range(1, 9)
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=buttons)
+
+
+def dishes_keyboard(dishes: List[Dict[str, Any]]) -> InlineKeyboardMarkup:
+    kb = [
+        [InlineKeyboardButton(text=d["name"], callback_data=f"dish:{d['id']}")]
+        for d in dishes
+    ]
+    kb.append([InlineKeyboardButton(text="\u2705 Завершить заказ", callback_data="finish")])
+    return InlineKeyboardMarkup(inline_keyboard=kb)
+
+
+def register_handlers(dp: Dispatcher) -> None:
+    dp.message.register(cmd_start, commands={"start"})
+    dp.callback_query.register(table_chosen, lambda c: c.data.startswith("table"), OrderStates.choosing_table)
+    dp.callback_query.register(category_chosen, lambda c: c.data.startswith("cat"), OrderStates.choosing_category)
+    dp.callback_query.register(dish_chosen, lambda c: c.data.startswith("dish"), OrderStates.choosing_dish)
+    dp.callback_query.register(finish_order, lambda c: c.data == "finish", OrderStates.choosing_dish)
+
+
+async def cmd_start(message: types.Message, state: FSMContext) -> None:
+    await state.clear()
+    await message.answer("Выберите номер стола:", reply_markup=table_keyboard())
+    await state.set_state(OrderStates.choosing_table)
+
+
+async def table_chosen(call: types.CallbackQuery, state: FSMContext) -> None:
+    _, table_number = call.data.split(":")
+    await state.update_data(table_number=int(table_number))
+    categories = await get_categories()
+    await call.message.edit_text(
+        "Выберите категорию:", reply_markup=categories_keyboard(categories)
+    )
+    await state.set_state(OrderStates.choosing_category)
+
+
+async def category_chosen(call: types.CallbackQuery, state: FSMContext) -> None:
+    _, cat_id = call.data.split(":")
+    dishes = await get_dishes(int(cat_id))
+    dish_map = {d["id"]: d["name"] for d in dishes}
+    await state.update_data(items=[], dish_map=dish_map)
+    await call.message.edit_text("Выберите блюда:", reply_markup=dishes_keyboard(dishes))
+    await state.set_state(OrderStates.choosing_dish)
+
+
+async def dish_chosen(call: types.CallbackQuery, state: FSMContext) -> None:
+    _, dish_id = call.data.split(":")
+    data = await state.get_data()
+    dish_map: Dict[int, str] = data.get("dish_map", {})
+    items: List[Dict[str, Any]] = data.get("items", [])
+    name = dish_map.get(int(dish_id), f"#{dish_id}")
+    items.append({"id": int(dish_id), "name": name})
+    await state.update_data(items=items)
+    await call.answer(f"Добавлено: {name}")
+
+
+async def finish_order(call: types.CallbackQuery, state: FSMContext, bot: Bot) -> None:
+    data = await state.get_data()
+    items = data.get("items", [])
+    if not items:
+        await call.answer("Блюда не выбраны", show_alert=True)
+        return
+
+    table_number = data.get("table_number")
+    await save_order(items=items, table_number=table_number)
+    header = f"Стол {table_number}" if table_number else "Новый заказ"
+    text = header + ":\n" + "\n".join(f"- {i['name']}" for i in items)
+    bar_chat = int(os.getenv("BAR_CHAT_ID", "0"))
+    if bar_chat:
+        await bot.send_message(bar_chat, text)
+
+    await call.message.edit_text("Заказ сохранён", reply_markup=None)
+    await state.clear()

--- a/waiter_bot/menu.py
+++ b/waiter_bot/menu.py
@@ -1,0 +1,21 @@
+import os
+from typing import Any, Dict, List
+
+import aiohttp
+
+API_BASE_URL = os.getenv("API_BASE_URL", "http://localhost:8000/api")
+
+
+async def get_categories() -> List[Dict[str, Any]]:
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{API_BASE_URL}/categories/") as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+
+async def get_dishes(category_id: int) -> List[Dict[str, Any]]:
+    async with aiohttp.ClientSession() as session:
+        url = f"{API_BASE_URL}/dishes/?category={category_id}"
+        async with session.get(url) as resp:
+            resp.raise_for_status()
+            return await resp.json()


### PR DESCRIPTION
## Summary
- expand README with table selection info
- document table selection step in `waiter_bot` README
- expose bot modules in `waiter_bot/__init__.py`
- extend FSM handlers to ask for table number before choosing dishes

## Testing
- `pip install -r requirements.txt`
- `python -m waiter_bot.bot --help`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687af52935e48327b75cf7a951c3d3ce